### PR TITLE
perf?(core.wrapper): preferLocalBuild by default?

### DIFF
--- a/lib/core.nix
+++ b/lib/core.nix
@@ -916,6 +916,7 @@ in
             dontConfigure = true;
             dontPatch = true;
             dontFixup = true;
+            preferLocalBuild = true;
             name = package.name or "${package.pname or binName}-${version}";
             ${
               if builtins.isString (package.pname or binName) && package.pname or binName != "" then


### PR DESCRIPTION
https://nix.dev/manual/nix/2.33/protocols/json/derivation/options.html#preferLocalBuild

This prevents it from checking a remote cache for your wrapper derivation with your settings in it.

Many wrapper derivation generators for various programs in nixpkgs and external flakes set this in their derivation, as the derivation contains user provided settings which will not be in a remote cache.

For the vast majority of wrapper derivations, the cost of checking the network should far exceed the amount of time it takes to link/copy/convert the files in the wrapper derivation.

If you have already built your wrapper derivation locally, it will still check your local cache.