### PR TITLE
fix(wrapperModules.emacs): set `package-user-dir` variable

### DIFF
--- a/wrapperModules/e/emacs/module.nix
+++ b/wrapperModules/e/emacs/module.nix
@@ -67,6 +67,7 @@ This is done at the start of `early-init.el`.";
     content =
       lib.optionalString (config.userDirectory != null) ''
         (setq user-emacs-directory "${config.userDirectory}")
+        (setq package-user-dir (expand-file-name "elpa/" user-emacs-directory))
       ''
       + config.earlyConfigFile;
   };


### PR DESCRIPTION
Currently it gets set to a path in the nix store, due to --init-directory, making commands like list-packages, or any imperative package management command work