### PR TITLE
feat(wrapperModules.yazi): support init.lua

### DIFF
--- a/wrapperModules/y/yazi/module.nix
+++ b/wrapperModules/y/yazi/module.nix
@@ -434,6 +434,20 @@ in
       };
     };
   };
+  options.initLua = lib.mkOption {
+    default = null;
+    description = ''
+      Content of the init.lua file.
+    '';
+    type = lib.types.nullOr (lib.types.either lib.types.path lib.types.lines);
+    example = lib.literalMD ''
+      ```lua
+      require("session"):setup {
+        sync_yanked = true,
+      }
+      ```
+    '';
+  };
   options.generatedConfig.output = lib.mkOption {
     type = lib.types.str;
     default = config.outputName;
@@ -502,7 +516,7 @@ in
   }/${config.binName}-config";
   # using constructFiles instead of (pkgs.formats.toml {}).generate allows placeholders to refer to the final wrapper derivation in the options.
   config.constructFiles =
-    builtins.mapAttrs
+    (builtins.mapAttrs
       (n: v: {
         # generate the directory of toml files
         # use lib.mkOverride 0 to force the value to make sure they stay together
@@ -520,6 +534,14 @@ in
         theme = config.settings.theme;
         vfs = config.settings.vfs;
         package = config.settings.package;
+      }
+    )
+    // {
+      initlua = lib.mkIf (config.initLua != null) {
+        relPath = "${config.binName}-config/init.lua";
+        content =
+          if builtins.isPath config.initLua then builtins.readFile config.initLua else config.initLua;
       };
+    };
   config.meta.maintainers = [ wlib.maintainers.apetrovic6 ];
 }

--- a/wrapperModules/y/yazi/module.nix
+++ b/wrapperModules/y/yazi/module.nix
@@ -439,7 +439,7 @@ in
     description = ''
       Content of the init.lua file.
     '';
-    type = lib.types.nullOr (lib.types.either lib.types.path lib.types.lines);
+    type = lib.types.nullOr (lib.types.either wlib.types.linkable lib.types.lines);
     example = lib.literalMD ''
       ```lua
       require("session"):setup {
@@ -539,8 +539,8 @@ in
     // {
       initlua = lib.mkIf (config.initLua != null) {
         relPath = "${config.binName}-config/init.lua";
-        content =
-          if builtins.isPath config.initLua then builtins.readFile config.initLua else config.initLua;
+        content = lib.mkIf (!wlib.types.linkable.check config.initLua) config.initLua;
+        builder = lib.mkIf (wlib.types.linkable.check config.initLua) ''ln -s ${config.initLua} "$2"'';
       };
     };
   config.meta.maintainers = [ wlib.maintainers.apetrovic6 ];

--- a/wrapperModules/y/yazi/module.nix
+++ b/wrapperModules/y/yazi/module.nix
@@ -538,7 +538,8 @@ in
     )
     // {
       initlua = lib.mkIf (config.initLua != null) {
-        relPath = "${config.binName}-config/init.lua";
+        relPath = lib.mkOverride 0 "${config.binName}-config/init.lua";
+        output = lib.mkOverride 0 config.generatedConfig.output;
         content = lib.mkIf (!wlib.types.linkable.check config.initLua) config.initLua;
         builder = lib.mkIf (wlib.types.linkable.check config.initLua) ''ln -s ${config.initLua} "$2"'';
       };


### PR DESCRIPTION
I wanted to make use of yazi's [builtin session plugin](https://yazi-rs.github.io/docs/dds#session.lua) but found no way to set code for the `init.lua` file, so I added a new option for it, mimicking home-manager's `programs.yazi.initLua`.