### PR TITLE
fix(modules.systemd): new systemd module was importing wlib.modules.default

### DIFF
--- a/modules/systemd/check.nix
+++ b/modules/systemd/check.nix
@@ -333,7 +333,10 @@ test "systemd" {
             ...
           }:
           {
-            imports = [ wlib.modules.systemd ];
+            imports = [
+              wlib.modules.systemd
+              wlib.modules.default
+            ];
             package = pkgs.runCommand "test-pkg" { } ''
               mkdir -p $out/lib/systemd/user
               cat > $out/lib/systemd/user/test.service <<'EOF'

--- a/modules/systemd/module.nix
+++ b/modules/systemd/module.nix
@@ -907,7 +907,6 @@ let
 in
 {
   imports = [
-    wlib.modules.default
     ./config.nix
   ];
   config.meta.maintainers = [ wlib.maintainers.birdee ];


### PR DESCRIPTION
this was a debugging artifact that I forgot to remove.