### PR TITLE
chore(treewide): scheduled deprecations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,19 +37,5 @@
         default = import ./shell.nix { pkgs = getPkgs system; };
       });
       formatter = forAllSystems (system: (getPkgs system).nixfmt-tree);
-      wrappedModules = lib.mapAttrs (
-        _:
-        lib.warn ''
-          Attention: `inputs.nix-wrapper-modules.wrappedModules` is deprecated, use `inputs.nix-wrapper-modules.wrappers` instead
-
-          Apologies for any inconvenience this has caused, but they are only the config set of a module, not a module themselves.
-
-          In addition, it was very hard to tell the name apart from its actual module counterpart, and it was longer than convenient.
-
-          This will be the last time these output names are changing, as a flake-parts module has been added for users to import.
-
-          This output will be removed on August 31, 2026
-        ''
-      ) self.wrappers;
     };
 }

--- a/lib/core.nix
+++ b/lib/core.nix
@@ -995,17 +995,7 @@ in
           '';
           initial = pkgs.callPackage config.builderFunction (
             args
-            // rec {
-              wrapper = lib.warn ''
-                the `wrapper` argument of config.builderFunction is deprecated.
-
-                Instead of `wrapper`, you will need to run `buildCommand` argument instead.
-
-                It contains the sorted and concatenated value of `config.buildCommand` DAG option
-
-                If you wish to sort the `config.buildCommand` DAG yourself instead, this is fine,
-                but it has been provided in sorted form via the `buildCommand` argument for convenience.
-              '' buildCommand;
+            // {
               buildCommand = lib.pipe config.buildCommand [
                 (wlib.dag.unwrapSort "buildCommand")
                 (map (v: v.data))

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -141,7 +141,7 @@ in
     # in a nixos module
     { ... }: {
       imports = [
-        (installModule { name = "?"; value = someWrapperModule; })
+        (getInstallModule { name = "?"; value = someWrapperModule; })
       ];
       config.wrappers."?" = {
         enable = true;
@@ -154,7 +154,7 @@ in
     # in a home-manager module
     { ... }: {
       imports = [
-        (installModule { name = "?"; value = someWrapperModule; })
+        (getInstallModule { name = "?"; value = someWrapperModule; })
       ];
       config.wrappers."?" = {
         enable = true;
@@ -801,82 +801,4 @@ in
   */
   ignoreSpecField = lib.mkIf false null;
 
-  mkInstallModule =
-    lib.warn
-      ''
-        mkInstallModule deprecated: use `installModule`, or grab `flake.wrappers.<name>.install` (or any other method of setting `config.install.optionLocation` and retrieving that value)
-
-        This function will be removed on August 31, 2026
-      ''
-      (
-        {
-          optloc ? [ "wrappers" ],
-          loc ? [
-            "environment"
-            "systemPackages"
-          ],
-          as_list ? true,
-          name,
-          value,
-          ...
-        }@args:
-        {
-          pkgs ? null,
-          lib,
-          config,
-          ...
-        }:
-        # https://github.com/NixOS/nixpkgs/blob/c171bfa97744c696818ca23d1d0fc186689e45c7/lib/modules.nix#L615C1-L623C25
-        builtins.intersectAttrs {
-          _class = null;
-          _file = null;
-          key = null;
-          disabledModules = null;
-          imports = null;
-          meta = null;
-          freeformType = null;
-        } args
-        // {
-          options = lib.setAttrByPath (optloc ++ [ name ]) (
-            lib.mkOption {
-              default = { };
-              description = ''
-                wrapper module for `${name}` as a submodule option
-              '';
-              type = wlib.types.subWrapperModule (
-                (lib.toList value)
-                ++ [
-                  {
-                    _file = ./lib.nix;
-                    config.pkgs = lib.mkIf (pkgs != null) pkgs;
-                    options.enable = lib.mkEnableOption name;
-                  }
-                ]
-              );
-            }
-          );
-          config = lib.setAttrByPath loc (
-            lib.mkIf
-              (lib.getAttrFromPath (
-                optloc
-                ++ [
-                  name
-                  "enable"
-                ]
-              ) config)
-              (
-                let
-                  res = lib.getAttrFromPath (
-                    optloc
-                    ++ [
-                      name
-                      "wrapper"
-                    ]
-                  ) config;
-                in
-                if as_list then [ res ] else res
-              )
-          );
-        }
-      );
 }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -403,7 +403,6 @@ in
       lib.types.str.check x && builtins.match "[ \t\n]*" x == null && builtins.match "[^\n\r]*" != null;
     inherit (lib.types.str) merge;
   };
-  nonEmptyline = lib.warn "`wlib.types.nonEmptyline` is deprecated due to having a mistake in its name, use `wlib.types.nonEmptyLine`" wlib.types.nonEmptyLine;
 
   /**
     Arguments:

--- a/modules/makeWrapper/module.nix
+++ b/modules/makeWrapper/module.nix
@@ -461,61 +461,23 @@ let
           Adds prefixed entries to the DAG under the name `NIX_LIB_PREFIXES`
         '';
       };
-      options.${optionalAttribute "extraPackages"} = lib.mkOption {
-        type = lib.types.listOf lib.types.package;
-        default =
-          if mainConfig != null && config.mirror or false then mainConfig.extraPackages or [ ] else [ ];
-        internal = true;
-        apply =
-          val:
-          if val != [ ] then
-            (builtins.warn ''
-              `extraPackages` is deprecated, use `runtimePkgs` instead.
-              `extraPackages` will be removed on August 31, 2026.
-            '' val)
-          else
-            val;
-      };
-      options.${optionalAttribute "runtimeLibraries"} = lib.mkOption {
-        type = lib.types.listOf lib.types.package;
-        default =
-          if mainConfig != null && config.mirror or false then mainConfig.runtimeLibraries or [ ] else [ ];
-        internal = true;
-        apply =
-          val:
-          if val != [ ] then
-            (builtins.warn ''
-              `runtimeLibraries` is deprecated, use `runtimeLibs` instead.
-              `runtimeLibraries` will be removed on August 31, 2026.
-            '' val)
-          else
-            val;
-      };
       config.${
-        if
-          excluded.runtimePkgs or false
-          && excluded.runtimeLibs or false
-          && excluded.extraPackages or false
-          && excluded.runtimeLibraries or false
-        then
-          null
-        else
-          "suffixVar"
+        if excluded.runtimePkgs or false && excluded.runtimeLibs or false then null else "suffixVar"
       } =
-        lib.optional (extraPath.post != [ ] || config.extraPackages or [ ] != [ ]) {
+        lib.optional (extraPath.post != [ ]) {
           name = "NIX_PATH_ADDITIONS";
           data = [
             "PATH"
             ":"
-            "${lib.makeBinPath (extraPath.post ++ config.extraPackages or [ ])}"
+            "${lib.makeBinPath extraPath.post}"
           ];
         }
-        ++ lib.optional (extraLibs.post != [ ] || config.runtimeLibraries or [ ] != [ ]) {
+        ++ lib.optional (extraLibs.post != [ ]) {
           name = "NIX_LIB_ADDITIONS";
           data = [
             "LD_LIBRARY_PATH"
             ":"
-            "${lib.makeLibraryPath (extraLibs.post ++ config.runtimeLibraries or [ ])}"
+            "${lib.makeLibraryPath extraLibs.post}"
           ];
         };
       config.${
@@ -758,57 +720,8 @@ let
         );
       };
     };
-  deprecationMessage =
-    name:
-    (builtins.warn or builtins.trace) ''
-      WARNING: `(import wlib.modules.makeWrapper).${name}` is deprecated
-
-      It has been moved to `wlib.makeWrapper.${name}`
-    '';
-  error_message = "this function has been moved to `wlib.makeWrapper` and also requires `pkgs` or `callPackage` to be provided to it";
 in
 {
-  wrapAll =
-    {
-      wlib,
-      config,
-      pkgs ? null,
-      callPackage ? pkgs.callPackage or (throw error_message),
-      ...
-    }@args:
-    (deprecationMessage "wrapAll") wlib.makeWrapper.wrapAll (args // { inherit config callPackage; });
-  wrapMain =
-    {
-      wlib,
-      config,
-      pkgs ? null,
-      callPackage ? pkgs.callPackage or (throw error_message),
-      ...
-    }@args:
-    (deprecationMessage "wrapMain") wlib.makeWrapper.wrapMain (args // { inherit config callPackage; });
-  wrapVariants =
-    {
-      wlib,
-      config,
-      pkgs ? null,
-      callPackage ? pkgs.callPackage or (throw error_message),
-      ...
-    }@args:
-    (deprecationMessage "wrapperVariants") wlib.makeWrapper.wrapVariants (
-      args // { inherit config callPackage; }
-    );
-  wrapVariant =
-    {
-      wlib,
-      config,
-      pkgs ? null,
-      callPackage ? pkgs.callPackage or (throw error_message),
-      ...
-    }@args:
-    (deprecationMessage "wrapVariant") wlib.makeWrapper.wrapVariant (
-      args // { inherit config callPackage; }
-    );
-
   wrapperFunction = null;
   # excluded_options.argv0 = true;  # both top & variants
   # excluded_options.top.argv0 = true;  # just top

--- a/wrapperModules/m/mangowc/module.nix
+++ b/wrapperModules/m/mangowc/module.nix
@@ -191,12 +191,6 @@
         '';
       };
 
-      extraContent = mkOption {
-        type = types.lines;
-        default = "";
-        internal = true;
-      };
-
       hotReload.enable = lib.mkOption {
         type = lib.types.bool;
         default = true;
@@ -244,19 +238,12 @@
             sourcedFileToSourceExpression =
               sourcedFile:
               if isImpurePath sourcedFile then "source-optional=${sourcedFile}" else "source=${sourcedFile}";
-            extraConfig =
-              if config.extraContent or "" != "" then
-                lib.warn "wrapperModules.mangowc: config.extraContent is deprecated, please use config.extraConfig instead" (
-                  config.extraContent
-                )
-              else
-                config.extraConfig;
           in
           (lib.strings.concatMapStringsSep "\n" sourcedFileToSourceExpression config.sourcedFiles)
           + "\n"
           + settingsString
           + "\n"
-          + extraConfig
+          + config.extraConfig
           + "\n"
           + lib.optionalString (
             config.autostart_sh != ""

--- a/wrapperModules/m/mpv/module.nix
+++ b/wrapperModules/m/mpv/module.nix
@@ -42,19 +42,6 @@ in
 {
   imports = [ wlib.modules.default ];
   options = {
-    scripts = lib.mkOption {
-      type = lib.types.listOf lib.types.package;
-      default = [ ];
-      internal = true;
-      apply =
-        x:
-        lib.warnIf (x != [ ])
-          "nix-wrapper-modules#mpv deprecation warning: `config.scripts` is deprecated, use `config.script.<name>.path = pkgs.mpvScripts.<name>` instead"
-          x;
-      description = ''
-        deprecated: use `config.script.<name>.path = pkgs.mpvScripts.<name>`
-      '';
-    };
     script = lib.mkOption {
       type = lib.types.attrsOf (
         lib.types.submodule (
@@ -322,17 +309,15 @@ in
 
   config.passthru.generatedConfig = dirOf config.constructFiles.generatedConfig.outPath;
 
-  config.overrides =
-    lib.mkIf (config.scripts or [ ] != [ ] || partitioned.nixpkgsScripts or [ ] != [ ])
-      [
-        {
-          name = "MPV_SCRIPTS";
-          type = "override";
-          data = prev: {
-            scripts = (prev.scripts or [ ]) ++ config.scripts ++ partitioned.nixpkgsScripts;
-          };
-        }
-      ];
+  config.overrides = lib.mkIf (partitioned.nixpkgsScripts or [ ] != [ ]) [
+    {
+      name = "MPV_SCRIPTS";
+      type = "override";
+      data = prev: {
+        scripts = (prev.scripts or [ ]) ++ partitioned.nixpkgsScripts;
+      };
+    }
+  ];
   config.package = lib.mkDefault pkgs.mpv;
   config.meta.maintainers = [ wlib.maintainers.birdee ];
 }

--- a/wrapperModules/n/niri/module.nix
+++ b/wrapperModules/n/niri/module.nix
@@ -67,18 +67,6 @@ in
   ];
 
   options = {
-    v2-settings = lib.mkOption {
-      type = lib.types.nullOr lib.types.bool;
-      default = null;
-      internal = true;
-      apply =
-        x:
-        lib.warnIf (x != null) ''
-          nix-wrapper-modules niri v2-settings option no longer has any effect!
-          `v2-settings == true` is now the default behaviour, and the deprecations for v1 have been removed.
-          You should remove `v2-settings = true` from your config, this option will be removed in a future version.
-        '';
-    };
     settings = lib.mkOption {
       description = ''
         Niri configuration settings.

--- a/wrapperModules/z/zsh/module.nix
+++ b/wrapperModules/z/zsh/module.nix
@@ -60,7 +60,7 @@ in
 
       ```nix
       { config, ... }: {
-        imports = [ (wlib.installModule { name = "zsh"; value = ./yourzshwrappermodule.nix; }) ];
+        imports = [ (wlib.getInstallModule { name = "zsh"; value = ./yourzshwrappermodule.nix; }) ];
         wrappers.zsh.enable = true;
         wrappers.zsh.asSystemDefault = true;
         users.users.''${username}.shell = config.wrappers.zsh.wrapper;


### PR DESCRIPTION
Most deprecation warnings were explicitly scheduled to be removed a week or 2 ago. The rest of the deprecation warnings have been around longer than those warnings. As a result, all deprecation warnings have now been removed.