### PR TITLE
feat(wrapperModules.nh): init, expose more configuration options and add check.nix

### DIFF
--- a/wrapperModules/n/nh/check.nix
+++ b/wrapperModules/n/nh/check.nix
@@ -1,0 +1,74 @@
+{
+  pkgs,
+  self,
+  tlib,
+  lib,
+  ...
+}:
+
+let
+  inherit (tlib) test;
+in
+test { wrapper = "nh"; } {
+  "wrapper initialization" =
+    let
+      wrapper = self.wrappers.nh.wrap {
+        inherit pkgs;
+      };
+    in
+    "[[ -x ${wrapper}/bin/nh ]]";
+
+  "wrapper environment configuration" =
+    let
+      wrapper = self.wrappers.nh.wrap {
+        inherit pkgs;
+
+        package = lib.mkForce (
+          pkgs.writeShellScriptBin "nh" ''
+            env
+          ''
+        );
+        ask = true;
+        nom = false;
+        flake = "/foo/bar";
+        searchChannel = "nixos-26.05";
+
+        extraConfig = {
+          LOG = "verbose";
+        };
+      };
+    in
+    ''
+      output="$(${wrapper}/bin/nh)"
+      [[ "$output" = *"NH_ASK=1"* ]]
+      [[ "$output" = *"NH_NOM=0"* ]]
+      [[ "$output" = *"NH_FLAKE=/foo/bar"* ]]
+      [[ "$output" = *"NH_SEARCH_CHANNEL=nixos-26.05"* ]]
+      [[ "$output" = *"NH_LOG=verbose"* ]]
+    '';
+
+  "dedicated option precedence" =
+    let
+      wrapper = self.wrappers.nh.wrap {
+        inherit pkgs;
+
+        package = lib.mkForce (
+          pkgs.writeShellScriptBin "nh" ''
+            env
+          ''
+        );
+        flake = "/foo/bar";
+        searchChannel = "nixos-26.05";
+
+        extraConfig = {
+          FLAKE = "/bar/baz";
+          SEARCH_CHANNEL = "nixos-25.11";
+        };
+      };
+    in
+    ''
+      output=$(${wrapper}/bin/nh)
+      [[ "$output" = *"NH_FLAKE=/foo/bar"* ]]
+      [[ "$output" = *"NH_SEARCH_CHANNEL=nixos-26.05"* ]]
+    '';
+}

--- a/wrapperModules/n/nh/module.nix
+++ b/wrapperModules/n/nh/module.nix
@@ -8,20 +8,76 @@
 {
   imports = [ wlib.modules.default ];
 
-  options.flake = lib.mkOption {
-    type = lib.types.str;
-    default = "/etc/nixos";
-    description = "Preferred path/reference to a directory containing your flake.nix used by NH when running flake-based commands";
+  options = {
+    ask = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Ask for confirmation before applying supported operations";
+    };
+
+    nom = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Use nix-output-monitor for Nix output";
+    };
+
+    flake = lib.mkOption {
+      type = lib.types.str;
+      default = "/etc/nixos";
+      description = ''
+        Preferred path/reference to a directory containing your flake.nix used by NH
+        when running flake-based commands
+      '';
+    };
+
+    searchChannel = lib.mkOption {
+      type = lib.types.str;
+      default = "unstable";
+      description = ''
+        Default Nixpkgs channel used by nh search packages and nh search operations
+      '';
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = ''
+        Additional configuration for NH. Attribute names are prefixed with `NH_` when
+        converted to environment variables. Built-in options take precedence over any
+        attributes with conflicting names.
+      '';
+    };
   };
 
   config = {
     package = pkgs.nh;
-    env = {
-      "NH_FLAKE" = {
-        data = "${config.flake}";
-        esc-fn = toString;
+
+    env =
+      lib.mapAttrs' (
+        name: value:
+        lib.nameValuePair "NH_${name}" {
+          data = value;
+          esc-fn = toString;
+        }
+      ) config.extraConfig
+      // {
+        "NH_ASK" = {
+          data = toString config.ask;
+          esc-fn = toString;
+        };
+        "NH_NOM" = {
+          data = toString config.nom;
+          esc-fn = toString;
+        };
+        "NH_FLAKE" = {
+          data = "${config.flake}";
+          esc-fn = toString;
+        };
+        "NH_SEARCH_CHANNEL" = {
+          data = "${config.searchChannel}";
+          esc-fn = toString;
+        };
       };
-    };
 
     meta.maintainers = [ wlib.maintainers.nakibrayane ];
   };


### PR DESCRIPTION
Hello,

This PR extends the existing wrapper module for the [nh](https://github.com/nix-community/nh) nix helper, which previously had one option for the `NH_FLAKE` environment variable for `nix os switch` based commands. The addition I'm introducing does two things:
1. Exposes options for a few more common environment variables nh looks at (I'm fine with exposing more if desired), and
2. For the sake of staying as widely compatible as possible, there is an additional `extraConfig` which can be used to configure environment variables that do not have their own dedicated option.

Example:
```nix
{
  flake = "/foo/bar";

  # New - common settings, again I'm cool with adding more if desired
  ask = true;
  nom = false;
  searchChannel = "nixos-26.05";

  # New - anything else that isn't covered or appears over time
  extraConfig = {
    LOG = "verbose";
    ...
  };
```

***

I also included a `check.nix` for nh as well, all it's really doing is ensuring that the environment variables are being passed along properly, so naturally the tests force override the package with env for ease of validation.

```nix
# For testing purposes only
package = lib.mkForce (           
  pkgs.writeShellScriptBin "nh" ''
    env                           
  ''                              
);                                
```