### PR TITLE
feat(wrapperModules.opencode): add option for configurating tui settings

### DIFF
--- a/maintainers/default.nix
+++ b/maintainers/default.nix
@@ -121,4 +121,10 @@
     github = "aliaslion";
     githubId = 122117018;
   };
+  lodwkobku = {
+    email = "lodwkobku+nixpkgs@gmail.com";
+    github = "LodWKobku";
+    githubId = 101132529;
+    name = "LodWKobku";
+  };
 }

--- a/wrapperModules/o/opencode/module.nix
+++ b/wrapperModules/o/opencode/module.nix
@@ -7,18 +7,37 @@
 }:
 {
   imports = [ wlib.modules.default ];
-  options.settings = lib.mkOption {
-    type = wlib.types.structuredValueWith { typeName = "JSON"; };
-    default = { };
-    description = "Sets OPENCODE_CONFIG for github:sst/opencode";
+  options = {
+    settings = lib.mkOption {
+      type = wlib.types.structuredValueWith { typeName = "JSON"; };
+      default = { };
+      description = "Sets OPENCODE_CONFIG for github:sst/opencode";
+    };
+    tui-settings = lib.mkOption {
+      type = wlib.types.structuredValueWith { typeName = "JSON"; };
+      default = { };
+      description = "Sets OPENCODE_TUI_CONFIG for github:sst/opencode";
+    };
   };
   config = {
-    meta.maintainers = [ wlib.maintainers.birdee ];
+    meta.maintainers = [
+      wlib.maintainers.birdee
+      wlib.maintainers.lodwkobku
+    ];
     package = lib.mkDefault pkgs.opencode;
-    envDefault.OPENCODE_CONFIG = config.constructFiles.generatedConfig.path;
-    constructFiles.generatedConfig = {
-      relPath = "${config.binName}-config.json";
-      content = builtins.toJSON config.settings;
+    envDefault = {
+      OPENCODE_CONFIG = config.constructFiles.opencodeConfig.path;
+      OPENCODE_TUI_CONFIG = config.constructFiles.opencodeTuiConfig.path;
+    };
+    constructFiles = {
+      opencodeConfig = {
+        relPath = "${config.binName}-config.json";
+        content = builtins.toJSON config.settings;
+      };
+      opencodeTuiConfig = {
+        relPath = "${config.binName}-tui-config.json";
+        content = builtins.toJSON config.tui-settings;
+      };
     };
   };
 }


### PR DESCRIPTION
In opencode configs for tui are read from it's [own file](https://opencode.ai/docs/config/#tui), separated from other settings. 
This commit extends constructFiles to create this file, and loads it using OPENCODE_TUI_CONFIG env var.