### PR TITLE
feat(wrapperModules.eza): init

### DIFF
--- a/maintainers/default.nix
+++ b/maintainers/default.nix
@@ -127,4 +127,9 @@
     githubId = 101132529;
     name = "LodWKobku";
   };
+  ionawr = {
+    name = "ionawr";
+    github = "ionawr";
+    githubId = 219933002;
+  };
 }

--- a/wrapperModules/e/eza/check.nix
+++ b/wrapperModules/e/eza/check.nix
@@ -1,0 +1,43 @@
+{
+  pkgs,
+  self,
+  tlib,
+  ...
+}:
+let
+  inherit (tlib)
+    isDirectory
+    isFile
+    test
+    ;
+
+  sampleTheme = {
+    filekinds.normal.foreground = "Blue";
+    perms.user_read = {
+      foreground = "Yellow";
+      is_bold = true;
+    };
+
+    filenames."Cargo.toml".icon.glyph = "🦀";
+
+    nix.icon = {
+      glyph = "❄";
+      style.foreground = "White";
+    };
+  };
+
+  ezaWrapper = self.wrappers.eza.wrap {
+    inherit pkgs;
+    theme = sampleTheme;
+  };
+in
+test { wrapper = "eza"; } {
+  "eza wrapper should be created" = isDirectory ezaWrapper;
+
+  "wrapper should output correct version" = ''
+    "${ezaWrapper}/bin/eza" --version |
+    grep -q "${ezaWrapper.version}"
+  '';
+
+  "eza wrapper should contain the theme config file" = isFile "${ezaWrapper}/eza/theme.yml";
+}

--- a/wrapperModules/e/eza/module.nix
+++ b/wrapperModules/e/eza/module.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  wlib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  yamlFmtType = wlib.types.structuredValueWith {
+    typeName = "YAML";
+  };
+in
+{
+  imports = [ wlib.modules.default ];
+
+  options = {
+    theme = lib.mkOption {
+      type = yamlFmtType;
+      default = { };
+      description = ''
+        Theme configuration for eza.
+        See <https://github.com/eza-community/eza/blob/main/man/eza_colors-explanation.5.md> for all available options.
+      '';
+    };
+  };
+
+  config = {
+    package = lib.mkDefault pkgs.eza;
+
+    env.EZA_CONFIG_DIR = lib.dirOf config.constructFiles.generatedTheme.path;
+
+    constructFiles.generatedTheme = {
+      content = builtins.toJSON config.theme;
+      relPath = "${config.binName}/theme.yml"; # You must name the file `theme.yml`, no matter the directory you specify
+      builder = ''${pkgs.remarshal}/bin/json2yaml "$1" "$2"'';
+    };
+
+    meta.maintainers = [ wlib.maintainers.ionawr ];
+  };
+}


### PR DESCRIPTION
added a `wrapperModule` for [`eza`](https://github.com/eza-community/eza).

it seems currently `eza` only takes theme options through its config directory, so i added only one option (`theme`) to set it.

please let me know if anything should be changed!